### PR TITLE
CI for GTK 3.10 with shippable

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,29 @@
+language: go
+
+build_image: shippableimages/ubuntu1404_go
+
+go:
+  - tip
+
+before_install:
+  - sudo apt-get update -y
+  - sudo apt-get install -y libglib2.0-dev libcairo2-dev libgtk-3-dev xvfb
+  - source $HOME/.gvm/scripts/gvm;
+  - if [[ $SHIPPABLE_GO_VERSION == "tip" ]]; then gvm install tip; gvm use tip; fi
+  - if [[ $SHIPPABLE_GO_VERSION == *release* ]]; then gvm install release; gvm use release; fi
+  - if [[ $SHIPPABLE_GO_VERSION =~ [0-9].[0-9] ]]; then gvm install go$SHIPPABLE_GO_VERSION; gvm use go$SHIPPABLE_GO_VERSION; fi
+  - export GOPATH=$SHIPPABLE_GOPATH
+  - go get github.com/t-yuki/gocover-cobertura
+  - go get github.com/onsi/gomega
+  - go get github.com/onsi/ginkgo
+  - go get code.google.com/p/go.tools/cmd/cover
+  - "export DISPLAY=:99.0"
+  - /usr/bin/Xvfb :99 &
+  
+install:
+  - go build -tags gtk_3_10 -v ./...
+
+script:
+  - go test -tags gtk_3_10 -coverprofile=coverage_gtk.txt -covermode count ./gtk
+  - go test -tags gtk_3_10 ./glib
+  - $GOPATH/bin/gocover-cobertura < coverage_gtk.txt > shippable/codecoverage/coverage_gtk.xml


### PR DESCRIPTION
This adds support for CI with shippable.
They have a Ubuntu 14.04 image (GTK 3.10)